### PR TITLE
Fix/handle missing data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ const MAX_QUOTE_ASSETS = 5;
 
 let logger = winston.createLogger({
   level: 'info',
+  format: winston.format.combine(
+    winston.format.errors({ stack: true }),
+    winston.format.json()
+  ),
   transports: [
     new winston.transports.Console(),
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,8 @@ export const fetchDirectSpotExchangeRate = async (baseAsset: string, quoteAsset:
   const response = await fetchMarketData('us', `spot_direct_exchange_rate/${baseAsset}/${quoteAsset}/recent`, `interval=${interval}&limit=1`);
   return {
     quoteAsset,
-    volume: new Big(response.data[0].volume),
-    price: new Big(response.data[0].price)
+    volume: new Big(response.data[0] ? response.data[0].volume : 0),
+    price: new Big(response.data[0] ? response.data[0].price : 0)
   };
 };
 
@@ -77,7 +77,7 @@ export const fetchRate = async (baseAsset: string, quoteAsset: string, interval:
   ]);
   return {
     quoteAsset,
-    volume: baseQuote.volume,
+    volume: quoteUSD.volume.eq(0) ? quoteUSD.volume : baseQuote.volume,
     price: baseQuote.price.mul(quoteUSD.price)
   };
 };


### PR DESCRIPTION
Motivation: In case there are no trades for an instrument during the requested interval, the result will be `null`. This can be seen currently as `ampl-usd` on Bitfinex hasn't had any volume at all for the past hours.

One way around this would be to increase the `limit` parameter (e.g. if `interval=5m` and `limit=288`, the most recent 5 minute interval during the past 24h will be used).


This PR treats missing data as if volume is 0 and omits those instruments from the result. Also adds proper logging of errors with stack trace.