### PR TITLE
Fix entrypoint path in generated package.json

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -7,12 +7,12 @@
     "url": "git+https://github.com/challengerdeep/exchange-rates-vwap-chainlink-adapter.git"
   },
   "license": "MIT",
-  "main": "./dist/index.js",
+  "main": "./index.js",
   "scripts": {
     "build": "npx tsc",
-    "postbuild": "cp package*.json ./dist",
-    "lint": "tslint --config tslint.json '*.ts' 'src/**/*.ts' 'test/**.*.ts' -t verbose",
-    "test": "TS_NODE_FILES=true mocha -r ts-node/register test/**/*.test.ts",
+    "postbuild": "cp package-lock.json ./dist; sed 's#./index.js#./index.js#' package.json > ./dist/package.json",
+    "lint": "npx tslint --config tslint.json '*.ts' 'src/**/*.ts' 'test/**.*.ts' -t verbose",
+    "test": "TS_NODE_FILES=true npx mocha -r ts-node/register test/**/*.test.ts",
     "watch": "npx tsc -w"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "npx tsc",
-    "postbuild": "cp package*.json ./dist",
-    "lint": "tslint --config tslint.json '*.ts' 'src/**/*.ts' 'test/**.*.ts' -t verbose",
-    "test": "TS_NODE_FILES=true mocha -r ts-node/register test/**/*.test.ts",
+    "postbuild": "cp package-lock.json ./dist; sed 's#./dist/index.js#./index.js#' package.json > ./dist/package.json",
+    "lint": "npx tslint --config tslint.json '*.ts' 'src/**/*.ts' 'test/**.*.ts' -t verbose",
+    "test": "TS_NODE_FILES=true npx mocha -r ts-node/register test/**/*.test.ts",
     "watch": "npx tsc -w"
   },
   "dependencies": {


### PR DESCRIPTION
This is to make the entrypoint path of the `package.json` in the dist folder correct - needed for seamless deployment via source repo for cloud functions.